### PR TITLE
refactor metaframe-generic-js-runtime -> metaframe-js

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@metapages/metaframe-generic-js-runtime",
+  "name": "@metapages/metaframe-js",
   "version": "0.1.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@metapages/metaframe-generic-js-runtime",
+      "name": "@metapages/metaframe-js",
       "version": "0.1.24",
       "hasInstallScript": true,
       "dependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@metapages/metaframe-generic-js-runtime",
+  "name": "@metapages/metaframe-js",
   "version": "0.1.24",
   "repository": {
     "type": "git",
-    "url": "https://github.com/metapages/metaframe-generic-js-runtime"
+    "url": "https://github.com/metapages/metaframe-js"
   },
   "files": [
     "dist/**/*"
@@ -11,7 +11,7 @@
   "type": "module",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",
-  "homepage": "https://github.com/metapages/metaframe-generic-js-runtime/tree/main/docs#readme",
+  "homepage": "https://github.com/metapages/metaframe-js/tree/main/docs#readme",
   "scripts": {
     "preinstall": "npm set progress=false && npm set audit false && npm config set fund false",
     "start": "vite",

--- a/client/src/components/ButtonGithub.tsx
+++ b/client/src/components/ButtonGithub.tsx
@@ -5,7 +5,7 @@ export const ButtonGithub: React.FC = () => {
   return (
     <Link
       _hover={undefined}
-      href="https://github.com/metapages/metaframe-generic-js-runtime"
+      href="https://github.com/metapages/metaframe-js"
       isExternal
     >
       <IconButton aria-label="github" icon={<AiFillGithub />} />

--- a/server/server.ts
+++ b/server/server.ts
@@ -242,7 +242,7 @@ const handler = (request: Request): Response => {
     // metaframeDefinition.metadata.operations.create = {
     //   type: "url",
     //   value: {
-    //     url: "https://metapages.github.io/metaframe-generic-js-runtime/",
+    //     url: "https://metapages.github.io/metaframe-js/",
     //     params: [
     //       {
     //         from: "js",
@@ -265,7 +265,7 @@ const handler = (request: Request): Response => {
     // metaframeDefinition.metadata.operations.create = {
     //   type: "url",
     //   value: {
-    //     url: "https://metapages.github.io/metaframe-generic-js-runtime/",
+    //     url: "https://metapages.github.io/metaframe-js/",
     //     params: [
     //       {
     //         from: "js",


### PR DESCRIPTION
It's a pointlessly long name. Simplify.